### PR TITLE
Fix avatar picker types and nullable refs

### DIFF
--- a/cue-console/src/components/chat/chat-dialogs.tsx
+++ b/cue-console/src/components/chat/chat-dialogs.tsx
@@ -4,7 +4,6 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import { getAgentEmoji } from "@/lib/utils";
-import { randomSeed } from "@/lib/avatar";
 
 interface PreviewDialogProps {
   previewImage: { mime_type: string; base64_data: string } | null;
@@ -40,10 +39,10 @@ interface AvatarPickerDialogProps {
   onOpenChange: (open: boolean) => void;
   avatarPickerTarget: { kind: "agent" | "group"; id: string } | null;
   avatarUrlMap: Record<string, string>;
-  avatarCandidates: Array<{ seed: number; url: string }>;
+  avatarCandidates: Array<{ seed: string; url: string }>;
   titleDisplay: string;
   onRandomize: () => Promise<void>;
-  onSelectAvatar: (seed: number) => Promise<void>;
+  onSelectAvatar: (seed: string) => Promise<void>;
 }
 
 export function AvatarPickerDialog({

--- a/cue-console/src/hooks/use-composer-height.ts
+++ b/cue-console/src/hooks/use-composer-height.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect, RefObject } from "react";
 
 interface UseComposerHeightProps {
-  inputWrapRef: RefObject<HTMLDivElement>;
+  inputWrapRef: RefObject<HTMLDivElement | null>;
 }
 
 export function useComposerHeight({ inputWrapRef }: UseComposerHeightProps) {
   const [composerPadPx, setComposerPadPx] = useState(36 * 4);
 
   useEffect(() => {
-    const el = inputWrapRef.current;
+    const el = inputWrapRef ? inputWrapRef.current : null;
     if (!el) return;
 
     const update = () => {

--- a/cue-console/src/hooks/use-paste-to-input.ts
+++ b/cue-console/src/hooks/use-paste-to-input.ts
@@ -7,7 +7,7 @@ interface UsePasteToInputProps {
   setMentions: (fn: (prev: MentionDraft[]) => MentionDraft[]) => void;
   reconcileMentionsByDisplay: (display: string, prev: MentionDraft[]) => MentionDraft[];
   closeMention: () => void;
-  textareaRef: RefObject<HTMLTextAreaElement>;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
 }
 
 export function usePasteToInput({

--- a/cue-console/src/hooks/use-textarea-autogrow.ts
+++ b/cue-console/src/hooks/use-textarea-autogrow.ts
@@ -1,7 +1,7 @@
 import { useEffect, RefObject } from "react";
 
 interface UseTextareaAutogrowProps {
-  textareaRef: RefObject<HTMLTextAreaElement>;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
   input: string;
 }
 


### PR DESCRIPTION
## Summary
- align avatar picker seed types with string seeds
- allow nullable refs in composer/textarea hooks

## Testing
- not run